### PR TITLE
Fixes async alerts 

### DIFF
--- a/custom_components/idfm/__init__.py
+++ b/custom_components/idfm/__init__.py
@@ -72,22 +72,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
-    entry_setups = []
+    platforms_to_setup = []
 
     for platform in PLATFORMS:
         if entry.options.get(platform, True):
             coordinator.platforms.append(platform)
-            entry_setups.append((entry, platform))
+            platforms_to_setup.append(platform)
 
-    if entry_setups:
+    if platforms_to_setup:
         hass.async_create_task(
-            hass.config_entries.async_forward_entry_setups(entry_setups)
+            hass.config_entries.async_forward_entry_setups(entry, platforms_to_setup)
         )
 
     entry.add_update_listener(async_reload_entry)
 
     return True
-
 
 class IDFMDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the API."""

--- a/custom_components/idfm/const.py
+++ b/custom_components/idfm/const.py
@@ -3,7 +3,7 @@
 NAME = "Ile de france mobilités"
 DOMAIN = "idfm"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "2.1.2"
+VERSION = "2.1.3"
 
 ISSUE_URL = "https://github.com/droso-hass/idfm/issues"
 

--- a/custom_components/idfm/const.py
+++ b/custom_components/idfm/const.py
@@ -3,7 +3,7 @@
 NAME = "Ile de france mobilités"
 DOMAIN = "idfm"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "2.1.3"
+VERSION = "2.1.4"
 
 ISSUE_URL = "https://github.com/droso-hass/idfm/issues"
 


### PR DESCRIPTION
This should fix the two errors thrown by Home Assistant regarding the usage of async_forward_entry_setup and async_add_job and ensure the plugin keeps working with upcoming updates