### PR TITLE
Two updates: (1) sensor.py to explicitly return None when there is no nth train (2) Modernize license and attribution

### DIFF
--- a/custom_components/idfm/const.py
+++ b/custom_components/idfm/const.py
@@ -42,6 +42,8 @@ ATTR_TRAFFIC_AT_STOP = "at_stop"
 ATTR_TRAFFIC_PLATFORM = "platform"
 ATTR_TRAFFIC_STATUS = "status"
 
+LICENSE_URL = "https://data.iledefrance-mobilites.fr/pages/licences/"
+ATTRIBUTION_COMPACT = f"Données © Île-de-France Mobilités — Licences: {LICENSE_URL}"
 
 STARTUP_MESSAGE = f"""
 -------------------------------------------------------------------

--- a/custom_components/idfm/entity.py
+++ b/custom_components/idfm/entity.py
@@ -1,13 +1,6 @@
 """IDFMEntity class"""
+from __future__ import annotations
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from idfm_api.attribution import (
-    IDFM_API_LICENCE,
-    IDFM_API_LICENCE_LINK,
-    IDFM_API_LINK,
-    IDFM_DB_LICENCE,
-    IDFM_DB_LICENCE_LINK,
-    IDFM_DB_SOURCES,
-)
 
 from .const import (
     CONF_DIRECTION,
@@ -18,13 +11,22 @@ from .const import (
     DOMAIN,
     NAME,
     VERSION,
+    ATTRIBUTION_COMPACT,
+    LICENSE_URL,
 )
 
 
 class IDFMEntity(CoordinatorEntity):
+    """Base entity for the IDFM integration."""
+    _attr_attribution = ATTRIBUTION_COMPACT
+    _attr_has_entity_name = True
+    
     def __init__(self, coordinator, config_entry):
         super().__init__(coordinator)
         self.config_entry = config_entry
+        self._attr_extra_state_attributes = {
+            "integration": DOMAIN,
+        }
 
     @property
     def unique_id(self):
@@ -33,13 +35,13 @@ class IDFMEntity(CoordinatorEntity):
 
     @property
     def device_info(self):
-        id = (
+        dev_id = (
             self.config_entry.data[CONF_LINE]
             + self.config_entry.data[CONF_STOP]
             + (self.config_entry.data[CONF_DIRECTION] or "any")
         )
         return {
-            "identifiers": {(DOMAIN, id)},
+            "identifiers": {(DOMAIN, dev_id)},
             "name": self.config_entry.data[CONF_LINE_NAME]
             + " - "
             + self.config_entry.data[CONF_STOP_NAME]
@@ -47,18 +49,6 @@ class IDFMEntity(CoordinatorEntity):
             + (self.config_entry.data[CONF_DIRECTION] or "any"),
             "model": VERSION,
             "manufacturer": NAME,
+            "configuration_url": LICENSE_URL,
         }
 
-    @property
-    def attribution(self) -> str:
-        """Return the attribution."""
-        static = "[" + ", ".join(IDFM_DB_SOURCES.values()) + "]"
-        return f"Static Data: {static} under {IDFM_DB_LICENCE}: {IDFM_DB_LICENCE_LINK} - API provided by PRIM: {IDFM_API_LINK} under {IDFM_API_LICENCE}: {IDFM_API_LICENCE_LINK}"
-
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
-        return {
-            "id": str(self.coordinator.data.get("id")),
-            "integration": DOMAIN,
-        }

--- a/custom_components/idfm/sensor.py
+++ b/custom_components/idfm/sensor.py
@@ -76,6 +76,7 @@ class IDFMTimeSensor(IDFMEntity, SensorEntity):
             self.coordinator.data[DATA_TRAFFIC]
         ):
             return as_local(self.coordinator.data[DATA_TRAFFIC][self.num].schedule)
+        return None
 
     @property
     def icon(self):


### PR DESCRIPTION
Two updates:

1. Explicitly return None when there is no nth train. Currently the integration returns 'unknown'.

   https://developers.home-assistant.io/docs/core/entity/sensor/ SensorDeviceClass.TIMESTAMP
   Timestamp. Requires native_value to return a Python datetime.datetime object, with time zone information, or None.
   >> This patch adds the None

   NB: In the UI it will still display as unknown (HA's rendering of None), but in automations/templates you can now check is none.

2. Use native HA functions for licence and attribution, reduces log clutter by no longer logging the long licence and attribution information.